### PR TITLE
Updated command to use transactions and avoid concurrency issues

### DIFF
--- a/Data/Fixtures/DemoWebsiteLoader.php
+++ b/Data/Fixtures/DemoWebsiteLoader.php
@@ -69,9 +69,12 @@ class DemoWebsiteLoader
         $sql = file_get_contents($filePath);
 
         try {
+            $this->connection->beginTransaction();
             $stmt = $this->connection->prepare($sql);
             $stmt->execute();
+            $this->connection->commit();
         } catch (\PDOException $e) {
+            $this->connection->rollback();
             throw new \RuntimeException($e->getMessage(), (int) $e->getCode(), $e);
         }
     }
@@ -94,8 +97,11 @@ class DemoWebsiteLoader
         $label  = $configuration['label'];
 
         try {
+            $this->connection->beginTransaction();
             $stmt = $this->connection->executeUpdate('UPDATE site SET server_name = ? , label = ?', array($domain, $label));
+            $this->connection->commit();
         } catch (\PDOException $e) {
+            $this->connection->rollback();
             throw new \RuntimeException($e->getMessage(), (int) $e->getCode(), $e);
         }
 


### PR DESCRIPTION
Previously, I have some issues when using my command on lock tables.

In my opinion, this is because Doctrine connection wasn't closed. So I have improved my Fixtures loader to commit transaction instead of hard query executions.

Ping @eric-chau 